### PR TITLE
feat(cadastro): adiciona páginas de cadastro de usuário e dependentes gerais

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import LoginIgreja from "./Pages/LoginIgreja";
 import PasswordRecovery from "./Pages/PasswordRecovery";
 import SecondPagePaciente from "./Pages/SecondPagePaciente";
 import CadastroEspecial from "./Pages/CadastroEspecial";
+import CadastroUsuario from "./Pages/CadastroUsuario";
 import Pacientes from "./Pages/Pacientes";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -140,6 +141,7 @@ function App() {
         {/* Rotas que não precisam de layout */}
         <Route path="/login-igreja" element={<LoginIgreja />} />
         <Route path="/password-recovery" element={<PasswordRecovery />} />
+        <Route path="/cadastro-usuario" element={<CadastroUsuario />} />
       </Routes>
       <ToastContainer position="top-right" autoClose={3000} />
     </Router>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import PasswordRecovery from "./Pages/PasswordRecovery";
 import SecondPagePaciente from "./Pages/SecondPagePaciente";
 import CadastroEspecial from "./Pages/CadastroEspecial";
 import CadastroUsuario from "./Pages/CadastroUsuario";
+import DependentesGeral from "./Pages/DependentesGeral";
 import Pacientes from "./Pages/Pacientes";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -142,6 +143,7 @@ function App() {
         <Route path="/login-igreja" element={<LoginIgreja />} />
         <Route path="/password-recovery" element={<PasswordRecovery />} />
         <Route path="/cadastro-usuario" element={<CadastroUsuario />} />
+        <Route path="/dependentes-geral" element={<DependentesGeral />} />
       </Routes>
       <ToastContainer position="top-right" autoClose={3000} />
     </Router>

--- a/src/Pages/CadastroUsuario.jsx
+++ b/src/Pages/CadastroUsuario.jsx
@@ -1,0 +1,226 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "../Components/Header"; 
+import Footer from "../Components/Footer"; 
+import Logo from "../assets/Logo.png"; 
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+
+const FormField = ({
+  label,
+  id,
+  type = "text",
+  placeholder,
+  colSpan = "col-span-1",
+  helperText,
+  value,
+  onChange,
+  required = false,
+  isPassword = false,
+  onToggleVisibility,
+}) => (
+  <div className={colSpan}>
+    <label
+      htmlFor={id}
+      className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1"
+    >
+      {label} {required && <span className="text-red-500">*</span>}
+    </label>
+    {helperText && (
+      <p className="text-[15px] text-[#0F276D] mb-1">{helperText}</p>
+    )}
+
+    <div className="relative w-full">
+      <input
+        type={type}
+        id={id}
+        name={id}
+        placeholder={placeholder}
+        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 pr-10"
+        value={value}
+        onChange={onChange}
+        required={required}
+      />
+
+      {/* ícone de olho */}
+      {isPassword && (
+        <button
+          type="button"
+          className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-500 hover:text-gray-700"
+          onClick={onToggleVisibility}
+        >
+          {type === "password" ? <FaEye /> : <FaEyeSlash />}
+        </button>
+      )}
+    </div>
+  </div>
+);
+
+export default function CadastroUsuario() {
+  const navigate = useNavigate();
+
+  // estado armazenado localmente
+  const [formData, setFormData] = useState({
+    nome: "",
+    cpf: "",
+    email: "",
+    senha: "",
+    confirmarSenha: "",
+  });
+
+  const [error, setError] = useState("");
+
+  // estado para controlar a visibilidade de cada campo
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  // função para atualizar o estado local
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  //  função de envio que processo os dados locais
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setError("");
+
+    // Verificação de senhas
+    if (formData.senha !== formData.confirmarSenha) {
+      setError("As senhas não conferem. Por favor, tente novamente.");
+      return;
+    }
+
+    // Verificação de segurança
+    if (formData.senha.length < 8) {
+      setError("A senha deve ter pelo menos 8 caracteres.");
+      return;
+    }
+
+    // navigate('/login');
+  };
+
+  return (
+    <div className="bg-gray-200 min-h-screen flex flex-col">
+      <Header />
+
+      <main className="flex-grow flex flex-col items-center gap-8 py-10 px-4 sm:px-6 pb-20 lg:pb-40">
+        <div className="w-full max-w-[1344px] flex flex-col sm:flex-row justify-center items-center gap-4 text-center sm:text-left">
+          <img
+            src={Logo}
+            alt="Logo da Instituição"
+            className="h-[70px] w-[70px] sm:h-[90px] sm:w-[90px]"
+          />
+          <h2 className="font-bold text-[#060F2A] text-2xl sm:text-3xl lg:text-4xl">
+            Sistema Integrado de Atendimento
+          </h2>
+        </div>
+
+        {/* Card Principal */}
+        <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-[0_8px_16px_rgba(113,146,255,0.25)] p-6 md:p-12">
+          <div className="text-center mb-8">
+            <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">
+              Cadastro de Novo Usuário
+            </h3>
+            <h5 className="text-[#0A1B4B] font-normal text-[16px] mt-4">
+              Preencha seus dados abaixo para criar uma conta.
+            </h5>
+          </div>
+
+          <form
+            className="max-w-4xl mx-auto mt-10 space-y-6"
+            onSubmit={handleSubmit}
+          >
+            <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+              Dados do Usuário
+            </h3>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 md:items-end">
+              <FormField
+                label="Nome completo"
+                id="nome"
+                placeholder="Digite seu nome e sobrenome"
+                colSpan="md:col-span-2"
+                value={formData.nome}
+                onChange={handleChange}
+                required
+              />
+              <FormField
+                label="CPF"
+                id="cpf"
+                placeholder="000.000.000-00"
+                value={formData.cpf}
+                onChange={handleChange}
+                required
+              />
+              <FormField
+                label="E-mail"
+                id="email"
+                type="email"
+                placeholder="email@exemplo.com"
+                value={formData.email}
+                onChange={handleChange}
+                required
+              />
+
+              <FormField
+                label="Senha"
+                placeholder="Mínimo de 8 caracteres"
+                helperText="Crie uma senha com no mínimo 8 caracteres."
+                value={formData.senha}
+                onChange={handleChange}
+                required
+                type={showPassword ? "text" : "password"}
+                isPassword={true}
+                onToggleVisibility={() => setShowPassword(!showPassword)}
+                id="senha"
+              />
+
+              <FormField
+                label="Confirmar Senha"
+                id="confirmarSenha"
+                placeholder="Repita sua senha"
+                helperText="Repita sua senha para confirmar"
+                value={formData.confirmarSenha}
+                onChange={handleChange}
+                required
+                type={showConfirmPassword ? "text" : "password"}
+                isPassword={true}
+                onToggleVisibility={() =>
+                setShowConfirmPassword(!showConfirmPassword)
+                }
+              />
+            </div>
+
+            {/* Exibição de Erro */}
+            {error && (
+              <p className="text-sm text-center font-semibold text-red-600">
+                {error}
+              </p>
+            )}
+
+            <div className="flex flex-col lg:flex-row justify-center items-center w-full gap-4 lg:gap-[24px] pt-6 border-t">
+              <button
+                type="submit"
+                className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#193FB0] font-bold text-lg border border-[#193FB0] rounded-[5px] shadow-[0_8px_16px_rgba(113,146,255,0.25)] hover:bg-[#193FB0] hover:text-white transition-all duration-300"
+              >
+                Cadastrar
+              </button>
+              <button
+                type="button"
+                className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#BE3E1A] font-bold text-lg border border-[#BE3E1A] rounded-[5px] hover:bg-[#BE3E1A] hover:text-white transition-all duration-300"
+                onClick={() => navigate("/")}
+              >
+                Cancelar
+              </button>
+            </div>
+            <h6 className="text-center font-bold text-[16px] text-[#0A1B4B]">
+              Suas informações são confidenciais e protegidas.
+            </h6>
+          </form>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/Pages/DependentesGeral.jsx
+++ b/src/Pages/DependentesGeral.jsx
@@ -1,0 +1,343 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Header from "../Components/Header"; 
+import Logo from "../assets/Logo.png";
+import Footer from "../Components/Footer"; 
+
+// Componente com value, onChange e disabled para controlar
+const FormField = ({
+  label,
+  id,
+  type = "text",
+  placeholder,
+  colSpan = "col-span-1",
+  helperText,
+  value,
+  onChange,
+  required = false,
+}) => (
+  <div className={colSpan}>
+    <label
+      htmlFor={id}
+      className={`block text-lg md:text-[20px] font-bold mb-1 "text-gray-400" : "text-[#0F276D]"
+      }`}
+    >
+      {label} {required && <span className="text-red-500">*</span>}
+    </label>
+    {helperText && (
+      <p className="text-[15px] text-[#0F276D] mb-1">{helperText}</p>
+    )}
+    <input
+      type={type}
+      id={id}
+      name={id}
+      placeholder={placeholder}
+      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
+      value={value}
+      onChange={onChange}
+
+    />
+  </div>
+);
+
+const RadioGroup = ({ label, name, options, selectedValue, onChange }) => (
+  <div>
+    <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-2">
+      {label}
+    </label>
+    <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+      {options.map((option) => (
+        <label key={option.value} className="flex items-center">
+          <input
+            type="radio"
+            name={name}
+            value={option.value}
+            checked={selectedValue === option.value}
+            onChange={onChange}
+            className="mr-2 w-5 h-5 accent-[#1D4BD1]"
+          />
+          {option.label}
+        </label>
+      ))}
+    </div>
+  </div>
+);
+
+export default function DependentesGeral() {
+  const navigate = useNavigate();
+
+  // armazena todos os dados do formulário
+  const [formData, setFormData] = useState({
+    // Dependente
+    nomeDependente: "",
+    dataNascimento: "",
+    // Responsável
+    usarMeusDados: "nao",
+    nomeResponsavel: "",
+    telefoneResponsavel: "",
+    // Saúde
+    alergia: "nao",
+    alergiaQual: "",
+    condicaoSaude: "nao",
+    condicaoSaudeQual: "",
+    observacoes: "",
+  });
+
+  // estado de erro para validação
+  const [error, setError] = useState("");
+
+  const handleChange = (e) => {
+    const { name, value, type } = e.target;
+
+    // checkbox Usar meus dados
+    if (name === "usarMeusDados") {
+      const usar = value === "sim";
+      setFormData((prev) => ({
+        ...prev,
+        usarMeusDados: value,
+        nomeResponsavel: usar ? "Maria da Luz Silva (Meu Usuário)" : "",
+        telefoneResponsavel: usar ? "98 9 1234-5678 (Meu Telefone)" : "",
+      }));
+    } else {
+      setFormData((prev) => ({
+        ...prev,
+        [name]: value,
+      }));
+    }
+  };
+
+  // função para salvar localmente
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    setError("");
+
+    // validação dos campos obrigatórios
+    if (!formData.nomeDependente || !formData.dataNascimento) {
+      setError(
+        "Nome completo e Data de nascimento do dependente são obrigatórios."
+      );
+      return;
+    }
+    if (
+      formData.usarMeusDados === "nao" &&
+      (!formData.nomeResponsavel || !formData.telefoneResponsavel)
+    ) {
+      setError(
+        "Nome e Telefone do responsável são obrigatórios se você não usar seus dados."
+      );
+      return;
+    }
+
+    // navigate("/");
+  };
+
+  return (
+    <div className="bg-gray-200 min-h-screen flex flex-col">
+      <Header />
+
+      <main className="flex-grow flex flex-col items-center gap-8 py-10 px-4 sm:px-6 pb-20 lg:pb-40">
+        {" "}
+
+        <div className="w-full max-w-[1344px] flex flex-col sm:flex-row justify-center items-center gap-4 text-center sm:text-left">
+          <img
+            src={Logo}
+            alt="Logo da Instituição"
+            className="h-[70px] w-[70px] sm:h-[90px] sm:w-[90px]"
+          />
+          <h2 className="font-bold text-[#060F2A] text-2xl sm:text-3xl lg:text-4xl">
+            Sistema Integrado de Atendimento
+          </h2>
+        </div>
+        {/* Card Principal do formulário */}
+        <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-[0_8px_16px_rgba(113,146,255,0.25)] p-6 md:p-12">
+          {/* Títulos do Card (Atualizados) */}
+          <div className="text-center mb-8">
+            <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">
+              Cadastro de Dependente para Atendimento Geral
+            </h3>
+            <h5 className="text-[#0A1B4B] font-normal text-[16px] mt-4">
+              Preencha os dados básicos do dependente para o atendimento.
+              <br />
+              Campos com * no fim significam campos obrigatórios.
+            </h5>
+          </div>
+
+          <form className="space-y-10" onSubmit={handleSubmit}>
+            {/* dados do dependente */}
+            <section>
+              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+                Dados do Dependente
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <FormField
+                  label="Nome completo"
+                  id="nomeDependente"
+                  name="nomeDependente"
+                  placeholder="Nome e sobrenomes do dependente"
+                  colSpan="md:col-span-3"
+                  value={formData.nomeDependente}
+                  onChange={handleChange}
+                  required
+                />
+                <FormField
+                  label="Data de nascimento"
+                  id="dataNascimento"
+                  name="dataNascimento"
+                  placeholder="DD/MM/AAAA"
+                  type="date"
+                  value={formData.dataNascimento}
+                  onChange={handleChange}
+                  required
+                />
+              </div>
+            </section>
+
+            {/* dados do responsável */}
+            <section>
+              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+                Dados do Responsável
+              </h3>
+
+              {/* checkbox "Usar meus dados" */}
+              <div className="mb-4">
+                <RadioGroup
+                  label="Nome da Mãe / Responsável*"
+                  name="usarMeusDados"
+                  selectedValue={formData.usarMeusDados}
+                  onChange={handleChange}
+                  options={[
+                    { value: "sim", label: "Usar os dados do meu cadastro" },
+                    { value: "nao", label: "Inserir manualmente" },
+                  ]}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <FormField
+                  label="Nome da Mãe / Responsável*"
+                  id="nomeResponsavel"
+                  name="nomeResponsavel"
+                  placeholder="[Nome, Sobrenome, Último nome]"
+                  colSpan="md:col-span-2"
+                  value={formData.nomeResponsavel}
+                  onChange={handleChange}
+                />
+                <FormField
+                  label="Telefone / Whatsapp*"
+                  id="telefoneResponsavel"
+                  name="telefoneResponsavel"
+                  placeholder="98 9 1234-5678"
+                  colSpan="md:col-span-1"
+                  value={formData.telefoneResponsavel}
+                  onChange={handleChange}
+                />
+              </div>
+            </section>
+
+            {/*informações de saude */}
+            <section>
+              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+                Informações de Saúde
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+                <div>
+                  <RadioGroup
+                    label="O dependente possui alguma alergia? Se sim, qual?*"
+                    name="alergia"
+                    selectedValue={formData.alergia}
+                    onChange={handleChange}
+                    options={[
+                      { value: "nao", label: "Não" },
+                      { value: "sim", label: "Sim" },
+                    ]}
+                  />
+                  <input
+                    type="text"
+                    name="alergiaQual"
+                    placeholder="[Campo de Texto]"
+                    className="w-full mt-2 px-4 py-2 border border-gray-300 rounded-lg"
+                    value={formData.alergiaQual}
+                    onChange={handleChange}
+                    disabled={formData.alergia === "nao"} 
+                  />
+                </div>
+                {/* Condição de Saúde */}
+                <div>
+                  <RadioGroup
+                    label="Possui alguma condição de saúde ou usa medicação contínua?*"
+                    name="condicaoSaude"
+                    selectedValue={formData.condicaoSaude}
+                    onChange={handleChange}
+                    options={[
+                      { value: "nao", label: "Não" },
+                      { value: "sim", label: "Sim" },
+                    ]}
+                  />
+                  <input
+                    type="text"
+                    name="condicaoSaudeQual"
+                    placeholder="[Campo de Texto]"
+                    className="w-full mt-2 px-4 py-2 border border-gray-300 rounded-lg"
+                    value={formData.condicaoSaudeQual}
+                    onChange={handleChange}
+                    disabled={formData.condicaoSaude === "nao"}
+                  />
+                </div>
+                {/* Observações */}
+                <div className="md:col-span-2">
+                  <label
+                    htmlFor="observacoes"
+                    className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1"
+                  >
+                    OBSERVAÇÕES (Se desejar):
+                  </label>
+                  <textarea
+                    id="observacoes"
+                    name="observacoes"
+                    rows="4"
+                    placeholder="[Campo de Texto]"
+                    className="w-full mt-1 px-4 py-2 border border-gray-300 rounded-lg"
+                    value={formData.observacoes}
+                    onChange={handleChange}
+                  ></textarea>
+                </div>
+              </div>
+            </section>
+
+            {/* Exibição de Erro */}
+            {error && (
+              <p className="text-sm text-center font-semibold text-red-600">
+                {error}
+              </p>
+            )}
+
+            {/* Botões de Ação */}
+            <div className="flex justify-center items-center pt-6 border-t">
+              <div className="flex flex-col lg:flex-row justify-center items-center w-full gap-4 lg:gap-[24px]">
+                <button
+                  type="submit"
+                  className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#193FB0] font-bold text-lg border border-[#193FB0] rounded-[5px] shadow-[0_8px_16px_rgba(113,146,255,0.25)] hover:bg-[#193FB0] hover:text-white transition-all duration-300"
+                >
+                  Salvar Cadastro e prosseguir
+                </button>
+                <button
+                  type="button"
+                  className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#BE3E1A] font-bold text-lg border border-[#BE3E1A] rounded-[5px] hover:bg-[#BE3E1A] hover:text-white transition-all duration-300"
+                  onClick={() => navigate("/")}
+                >
+                  Cancelar
+                </button>
+              </div>
+            </div>
+
+            <h6 className="text-center font-bold text-[16px] text-[#0A1B4B]">
+              Suas informações são confidenciais e protegidas.
+            </h6>
+          </form>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/Pages/DependentesGeral.jsx
+++ b/src/Pages/DependentesGeral.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import Header from "../Components/Header"; 
+import Header from "../Components/Header";
 import Logo from "../assets/Logo.png";
-import Footer from "../Components/Footer"; 
+import Footer from "../Components/Footer";
 
 // Componente com value, onChange e disabled para controlar
 const FormField = ({
@@ -14,12 +14,14 @@ const FormField = ({
   helperText,
   value,
   onChange,
+  disabled = false,
   required = false,
 }) => (
   <div className={colSpan}>
     <label
       htmlFor={id}
-      className={`block text-lg md:text-[20px] font-bold mb-1 "text-gray-400" : "text-[#0F276D]"
+      className={`block text-lg md:text-[20px] font-bold mb-1 ${
+        disabled ? "text-gray-400" : "text-[#0F276D]"
       }`}
     >
       {label} {required && <span className="text-red-500">*</span>}
@@ -35,7 +37,8 @@ const FormField = ({
       className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 disabled:text-gray-500"
       value={value}
       onChange={onChange}
-
+      disabled={disabled}
+      required={required}
     />
   </div>
 );
@@ -137,7 +140,6 @@ export default function DependentesGeral() {
 
       <main className="flex-grow flex flex-col items-center gap-8 py-10 px-4 sm:px-6 pb-20 lg:pb-40">
         {" "}
-
         <div className="w-full max-w-[1344px] flex flex-col sm:flex-row justify-center items-center gap-4 text-center sm:text-left">
           <img
             src={Logo}
@@ -150,7 +152,6 @@ export default function DependentesGeral() {
         </div>
         {/* Card Principal do formulário */}
         <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-[0_8px_16px_rgba(113,146,255,0.25)] p-6 md:p-12">
-          {/* Títulos do Card (Atualizados) */}
           <div className="text-center mb-8">
             <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">
               Cadastro de Dependente para Atendimento Geral
@@ -198,7 +199,7 @@ export default function DependentesGeral() {
                 Dados do Responsável
               </h3>
 
-              {/* checkbox "Usar meus dados" */}
+              {/* checkbox Usar meus dados */}
               <div className="mb-4">
                 <RadioGroup
                   label="Nome da Mãe / Responsável*"
@@ -221,6 +222,8 @@ export default function DependentesGeral() {
                   colSpan="md:col-span-2"
                   value={formData.nomeResponsavel}
                   onChange={handleChange}
+                  disabled={formData.usarMeusDados === "sim"}
+                  required={formData.usarMeusDados === "nao"}
                 />
                 <FormField
                   label="Telefone / Whatsapp*"
@@ -230,6 +233,8 @@ export default function DependentesGeral() {
                   colSpan="md:col-span-1"
                   value={formData.telefoneResponsavel}
                   onChange={handleChange}
+                  disabled={formData.usarMeusDados === "sim"}
+                  required={formData.usarMeusDados === "nao"}
                 />
               </div>
             </section>
@@ -258,7 +263,7 @@ export default function DependentesGeral() {
                     className="w-full mt-2 px-4 py-2 border border-gray-300 rounded-lg"
                     value={formData.alergiaQual}
                     onChange={handleChange}
-                    disabled={formData.alergia === "nao"} 
+                    disabled={formData.alergia === "nao"}
                   />
                 </div>
                 {/* Condição de Saúde */}


### PR DESCRIPTION
Implementa a nova página `CadastroUsuario.jsx` conforme a demanda,
para permitir o registro de novos usuários com nome, CPF, e-mail e senha.

- Estado Local, o estado do formulário (`formData`) é gerenciado localmente dentro do
  componente com `useState`, sem integração com a Context API.

- Validação, inclui validação local para verificar se as senhas (senha e confirmarSenha) conferem e se
  a senha atende ao requisito de 8 caracteres.
  
Implementa a página de cadastro de dependentes gerais ( DependentesGeral.jsx ) com estado local.
  
  Lógica Usar Meus Dados:

-O usuário pode escolher "Usar os dados do meu cadastro" ou "Inserir manualmente" para os dados do responsável.

-Ao selecionar "Usar meus dados", os campos de nome e telefone do responsável são preenchidos (com dados simulados) e desabilitados.

-A validação de obrigatoriedade desses campos só é aplicada se o usuário optar por "Inserir manualmente".