### PR TITLE
Refactor(ui): Padronização Visual nas páginas de cadastro de pacientes e Componentização do Formulário Global

### DIFF
--- a/src/CadastroContext.jsx
+++ b/src/CadastroContext.jsx
@@ -15,10 +15,6 @@ export function CadastroProvider({ children }) {
       estado_civil: '',
       email: '',
       possui_responsavel: false,
-      condicao_saude: '',
-      condicao_saude_outro: '',
-      possui_deficiencia: false,
-      deficiencia: '',
       observacoes: '',
       profissao: '',              
       situacao_empregaticia: '', 
@@ -44,19 +40,32 @@ export function CadastroProvider({ children }) {
     senha: '',
   });
 
-  // Função para atualizar os dados 
+  // função para atualizar os dados 
   const updateFormData = (newData) => {
     let updatedData;
     setFormData((prevData) => {
-      updatedData = { ...prevData };
+      // faz uma copia para garantir a imutabilidade
+      updatedData = { 
+        ...prevData,
+        paciente: { ...prevData.paciente },
+        endereco: { ...prevData.endereco },
+        responsavel: { ...prevData.responsavel }
+      };
 
-      // Verifica se os novos dados pertencem a paciente ou endereco
-      if ('nome' in newData || 'profissao' in newData) {
+      // verifica se é dado do Paciente
+      if ('nome' in newData || 'profissao' in newData || 'sexo' in newData || 'cpf' in newData) {
         updatedData.paciente = { ...prevData.paciente, ...newData };
-      } else if ('logradouro' in newData || 'bairro' in newData) {
+      } 
+      // verifica se é dado de endereço ( alterado para o padrão rua )
+      else if ('rua' in newData || 'bairro' in newData || 'cep' in newData) {
         updatedData.endereco = { ...prevData.endereco, ...newData };
-      } else {
-       
+      } 
+      // verifica se é dado do responsável
+      else if ('nome_responsavel' in newData || 'cpf_responsavel' in newData || 'parentesco' in newData) {
+        updatedData.responsavel = { ...prevData.responsavel, ...newData };
+      }
+
+      else {
         Object.assign(updatedData, newData);
       }
       
@@ -79,10 +88,6 @@ export function CadastroProvider({ children }) {
         estado_civil: '',
         email: '',
         possui_responsavel: false,
-        condicao_saude: null,
-        condicao_saude_outro: null,
-        possui_deficiencia: false,
-        deficiencia: null,
         observacoes: '',
         profissao: '',              
         situacao_empregaticia: '', 

--- a/src/Pages/CadastroPacientes.jsx
+++ b/src/Pages/CadastroPacientes.jsx
@@ -4,58 +4,9 @@ import { useCadastro } from "../CadastroContext";
 import Header from "../components/Header";
 import Logo from "../assets/Logo.png";
 import Footer from "../components/Footer";
+import FormField from "../components/FormField";
 import axios from "../services/axios.js";
 
-const FormField = ({
-  label,
-  id,
-  type = "text",
-  placeholder,
-  colSpan = "col-span-1",
-  helperText,
-  value,
-  onChange,
-  error,
-  required = false,
-  showHelper = true,
-}) => {
-  const showError = Boolean(error);
-
-  return (
-    <div className={`${colSpan} flex flex-col`}>
-      <label
-        htmlFor={id}
-        className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1"
-      >
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-
-      <input
-        type={type}
-        id={id}
-        name={id}
-        placeholder={placeholder}
-        className={`w-full px-4 py-2 border rounded-lg focus:ring-blue-500 focus:border-blue-500
-          ${showError ? "border-red-500" : "border-gray-300"}
-        `}
-        value={value}
-        onChange={onChange}
-      />
-
-      <div className="min-h-[1.25rem] mt-1">
-        {showError ? (
-          <p className="text-sm text-red-600">{error}</p>
-        ) : (
-          showHelper && (
-            <p className="text-[15px] text-[#0F276D] font-semibold">
-              {helperText}
-            </p>
-          )
-        )}
-      </div>
-    </div>
-  );
-};
 
 export default function CadastroPaciente() {
   const navigate = useNavigate();

--- a/src/Pages/CadastroPacientes.jsx
+++ b/src/Pages/CadastroPacientes.jsx
@@ -74,10 +74,6 @@ export default function CadastroPaciente() {
       email: formData.paciente.email || "",
       possui_responsavel: formData.paciente.possui_responsavel || false,
       sexo: formData.paciente.sexo || "",
-      condicao_saude: formData.paciente.condicao_saude || "",
-      condicao_saude_outro: formData.paciente.condicao_saude_outro || "",
-      possui_deficiencia: formData.paciente.possui_deficiencia || false,
-      deficiencia: formData.paciente.deficiencia || "",
       observacoes: formData.paciente.observacoes || "",
     },
     responsavel: {
@@ -107,16 +103,6 @@ export default function CadastroPaciente() {
       (value) => !value
     );
 
-    // Verifica campo de deficiência quando necessário
-    const deficiencyError =
-      localData.paciente.possui_deficiencia === true &&
-      !localData.paciente.deficiencia;
-
-    // Verifica campo de condição de saúde "Outro" quando necessário
-    const healthConditionError =
-      localData.paciente.condicao_saude === "Outro" &&
-      !localData.paciente.condicao_saude_outro;
-
     // Verifica campos do responsável quando necessário
     const responsavelError =
       localData.paciente.possui_responsavel &&
@@ -130,8 +116,6 @@ export default function CadastroPaciente() {
     return (
       hasValidationErrors ||
       hasMissingFields ||
-      deficiencyError ||
-      healthConditionError ||
       responsavelError
     );
   };
@@ -561,7 +545,7 @@ export default function CadastroPaciente() {
                 </div>
 
                 <div className="md:col-span-1">
-                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1 flex">
+                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
                     <h4>
                       Escolaridade <span className="text-red-500">*</span>
                     </h4>
@@ -603,7 +587,7 @@ export default function CadastroPaciente() {
                 </div>
 
                 <div className="md:col-span-1">
-                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1 flex">
+                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
                     <h4>
                       Estado Civil <span className="text-red-500">*</span>{" "}
                     </h4>

--- a/src/Pages/CadastroPacientes.jsx
+++ b/src/Pages/CadastroPacientes.jsx
@@ -16,14 +16,13 @@ const FormField = ({
   value,
   onChange,
   error,
-  required = false, // novo: opcional
-  showHelper = true, // novo: permite desligar helperText
+  required = false,
+  showHelper = true,
 }) => {
   const showError = Boolean(error);
 
   return (
     <div className={`${colSpan} flex flex-col`}>
-      {/* Label */}
       <label
         htmlFor={id}
         className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1"
@@ -31,7 +30,6 @@ const FormField = ({
         {label} {required && <span className="text-red-500">*</span>}
       </label>
 
-      {/* Campo */}
       <input
         type={type}
         id={id}
@@ -44,13 +42,14 @@ const FormField = ({
         onChange={onChange}
       />
 
-      {/* Espaço fixo para helper/erro */}
       <div className="min-h-[1.25rem] mt-1">
         {showError ? (
           <p className="text-sm text-red-600">{error}</p>
         ) : (
           showHelper && (
-            <p className="text-[15px] text-[#0F276D] font-semibold">{helperText}</p>
+            <p className="text-[15px] text-[#0F276D] font-semibold">
+              {helperText}
+            </p>
           )
         )}
       </div>
@@ -58,236 +57,12 @@ const FormField = ({
   );
 };
 
-
 export default function CadastroPaciente() {
   const navigate = useNavigate();
   const { formData, updateFormData } = useCadastro();
   const [errors, setErrors] = useState({});
 
-  // Função para verificar se há erros no formulário
-  const hasFormErrors = () => {
-    // Verifica se há algum erro nos campos já validados
-    const hasValidationErrors = Object.values(errors).some(error => error !== "");
-
-    // Verifica campos obrigatórios não preenchidos
-    const requiredFields = {
-      nome: localData.paciente.nome,
-      data_nascimento: localData.paciente.data_nascimento,
-      // cpf: localData.paciente.cpf,
-      escolaridade: localData.paciente.escolaridade,
-      estado_civil: localData.paciente.estado_civil,
-      // condicao_saude: localData.paciente.condicao_saude
-    };
-
-    const hasMissingFields = Object.values(requiredFields).some(value => !value);
-
-    // Verifica campo de deficiência quando necessário
-    const deficiencyError = localData.paciente.possui_deficiencia === true && !localData.paciente.deficiencia;
-
-    // Verifica campo de condição de saúde "Outro" quando necessário
-    const healthConditionError = localData.paciente.condicao_saude === "Outro" && !localData.paciente.condicao_saude_outro;
-
-    // Verifica campos do responsável quando necessário
-    const responsavelError = localData.paciente.possui_responsavel && (
-      !localData.responsavel.nome_responsavel ||
-      !localData.responsavel.cpf_responsavel ||
-      !localData.responsavel.parentesco ||
-      errors.nome_responsavel ||
-      errors.cpf_responsavel ||
-      errors.parentesco
-    );
-
-    return hasValidationErrors || hasMissingFields || deficiencyError || healthConditionError || responsavelError;
-  };
-
-  // Função para validar o nome completo
-  const validateNome = (nome) => {
-    if (!nome) return "Nome é obrigatório";
-    if (nome.length < 5) return "Nome deve ter pelo menos 5 caracteres";
-    if (!/^[A-Za-zÀ-ÖØ-öø-ÿ\s]*$/.test(nome)) return "Nome deve conter apenas letras e espaços";
-    if (nome.trim().split(/\s+/).length < 1) return "Por favor, insira o nome completo (nome e sobrenomes)";
-    return "";
-  };
-
-  const validateEmail = (email) => {
-    // Se o campo estiver vazio, não retorna erro pois é opcional
-    if (!email || email.trim() === "") return "";
-    
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) return "Digite um e-mail válido";
-    return "";
-  };
-
-  // const validateCPF = (cpf) => {  
-  //   // Remove caracteres não numéricos
-  //   const cleanCPF = cpf.replace(/[^\d]/g, '');
-    
-  //   if (cleanCPF.length !== 11) return "CPF deve ter 11 dígitos";
-    
-  //   // Verifica se todos os dígitos são iguais
-  //   if (/^(\d)\1{10}$/.test(cleanCPF)) return "CPF inválido";
-    
-  //   // Validação dos dígitos verificadores
-  //   let sum = 0;
-  //   let remainder;
-    
-  //   // Primeiro dígito verificador
-  //   for (let i = 1; i <= 9; i++) {
-  //     sum = sum + parseInt(cleanCPF.substring(i-1, i)) * (11 - i);
-  //   }
-    
-  //   remainder = (sum * 10) % 11;
-  //   if (remainder === 10 || remainder === 11) remainder = 0;
-  //   if (remainder !== parseInt(cleanCPF.substring(9, 10))) return "CPF inválido";
-    
-  //   // Segundo dígito verificador
-  //   sum = 0;
-  //   for (let i = 1; i <= 10; i++) {
-  //     sum = sum + parseInt(cleanCPF.substring(i-1, i)) * (12 - i);
-  //   }
-    
-  //   remainder = (sum * 10) % 11;
-  //   if (remainder === 10 || remainder === 11) remainder = 0;
-  //   if (remainder !== parseInt(cleanCPF.substring(10, 11))) return "CPF inválido";
-    
-  //   return "";
-  // };
-
-  const validateDataNascimento = (data) => {
-    if (!data) return "Data de nascimento é obrigatória";
-    
-    const dataNascimento = new Date(data);
-    const hoje = new Date();
-    
-    if (isNaN(dataNascimento.getTime())) return "Data de nascimento inválida";
-    if (dataNascimento > hoje) return "Data de nascimento não pode ser no futuro";
-    
-    return "";
-  };
-
-  const validateEscolaridade = (escolaridade) => {
-    if (!escolaridade) return "Escolaridade é obrigatória";
-    
-    const opcoesValidas = [
-      "Fundamental Incompleto",
-      "Fundamental Completo",
-      "Médio Incompleto",
-      "Médio Completo",
-      "Superior Incompleto",
-      "Superior Completo",
-      "Pós-graduação"
-    ];
-    
-    if (!opcoesValidas.includes(escolaridade)) return "Selecione uma opção válida";
-    
-    return "";
-  };
-
-  const validateEstadoCivil = (estadoCivil) => {
-    if (!estadoCivil) return "Estado civil é obrigatório";
-    
-    const opcoesValidas = [
-      "Solteiro(a)",
-      "Casado(a)",
-      "Divorciado(a)",
-      "Viúvo(a)",
-      "União Estável"
-    ];
-    
-    if (!opcoesValidas.includes(estadoCivil)) return "Selecione uma opção válida";
-    
-    return "";
-  };
-
-  // const validateCondicaoSaude = (condicao, outroValor) => {
-  //   if (!condicao) return "Por favor, selecione uma opção";
-    
-  //   const opcoesValidas = ["Diabetes", "Hipertensão", "Alergia", "Nenhuma", "Outro"];
-  //   if (!opcoesValidas.includes(condicao)) return "Selecione uma opção válida";
-    
-  //   if (condicao === "Outro" && !outroValor?.trim()) {
-  //     return "Por favor, especifique a condição de saúde";
-  //   }
-    
-  //   return "";
-  // };
-
-  // const validateDeficiencia = (possuiDeficiencia, deficiencia) => {
-  //   // Se não possui deficiência, não precisa validar
-  //   if (!possuiDeficiencia) return "";
-    
-  //   // Se possui deficiência, o campo de descrição é obrigatório
-  //   if (!deficiencia?.trim()) {
-  //     return "Por favor, especifique qual é a deficiência";
-  //   }
-    
-  //   // Verifica se a descrição tem pelo menos 3 caracteres
-  //   if (deficiencia.trim().length < 3) {
-  //     return "A descrição da deficiência deve ter pelo menos 3 caracteres";
-  //   }
-    
-  //   return "";
-  // };
-
-  // Funções de validação para os campos do responsável
-  const validateNomeResponsavel = (nome, possuiResponsavel) => {
-    if (!possuiResponsavel) return ""; // Se não possui responsável, não valida
-    if (!nome) return "Nome do responsável é obrigatório";
-    if (nome.length < 5) return "Nome do responsável deve ter pelo menos 5 caracteres";
-    if (!/^[A-Za-zÀ-ÖØ-öø-ÿ\s]*$/.test(nome)) return "Nome do responsável deve conter apenas letras e espaços";
-    if (nome.trim().split(/\s+/).length < 2) return "Por favor, insira nome e sobrenome do responsável";
-    return "";
-  };
-
-  const validateCPFResponsavel = (cpf, possuiResponsavel) => {
-    if (!possuiResponsavel) return ""; // Se não possui responsável, não valida
-    if (!cpf) return "CPF do responsável é obrigatório";
-    
-    // Remove caracteres não numéricos
-    const cleanCPF = cpf.replace(/[^\d]/g, '');
-    
-    if (cleanCPF.length !== 11) return "CPF do responsável deve ter 11 dígitos";
-    
-    // Verifica se todos os dígitos são iguais
-    if (/^(\d)\1{10}$/.test(cleanCPF)) return "CPF do responsável inválido";
-    
-    // Validação dos dígitos verificadores
-    let sum = 0;
-    let remainder;
-    
-    // Primeiro dígito verificador
-    for (let i = 1; i <= 9; i++) {
-      sum = sum + parseInt(cleanCPF.substring(i-1, i)) * (11 - i);
-    }
-    
-    remainder = (sum * 10) % 11;
-    if (remainder === 10 || remainder === 11) remainder = 0;
-    if (remainder !== parseInt(cleanCPF.substring(9, 10))) return "CPF do responsável inválido";
-    
-    // Segundo dígito verificador
-    sum = 0;
-    for (let i = 1; i <= 10; i++) {
-      sum = sum + parseInt(cleanCPF.substring(i-1, i)) * (12 - i);
-    }
-    
-    remainder = (sum * 10) % 11;
-    if (remainder === 10 || remainder === 11) remainder = 0;
-    if (remainder !== parseInt(cleanCPF.substring(10, 11))) return "CPF do responsável inválido";
-    
-    return "";
-  };
-
-  const validateParentesco = (parentesco, possuiResponsavel) => {
-    if (!possuiResponsavel) return ""; // Se não possui responsável, não valida
-    if (!parentesco) return "Selecione o parentesco do responsável";
-    
-    const opcoesValidas = ["mae", "pai", "avo", "tia", "tio", "irma", "irmao", "outro"];
-    if (!opcoesValidas.includes(parentesco)) return "Selecione uma opção válida de parentesco";
-    
-    return "";
-  };
-
-  //  Inicializa o estado local buscando dados de 'formData.paciente.*'
+  // Inicializa o estado local buscando dados de 'formData.paciente.*'
   const [localData, setLocalData] = useState({
     paciente: {
       nome: formData.paciente.nome || "",
@@ -313,15 +88,224 @@ export default function CadastroPaciente() {
     },
   });
 
+  // função para verificar se há erros no formulário
+  const hasFormErrors = () => {
+    // verifica se há algum erro nos campos já validados
+    const hasValidationErrors = Object.values(errors).some(
+      (error) => error !== ""
+    );
+
+    // Verifica campos obrigatórios não preenchidos
+    const requiredFields = {
+      nome: localData.paciente.nome,
+      data_nascimento: localData.paciente.data_nascimento,
+      escolaridade: localData.paciente.escolaridade,
+      estado_civil: localData.paciente.estado_civil,
+    };
+
+    const hasMissingFields = Object.values(requiredFields).some(
+      (value) => !value
+    );
+
+    // Verifica campo de deficiência quando necessário
+    const deficiencyError =
+      localData.paciente.possui_deficiencia === true &&
+      !localData.paciente.deficiencia;
+
+    // Verifica campo de condição de saúde "Outro" quando necessário
+    const healthConditionError =
+      localData.paciente.condicao_saude === "Outro" &&
+      !localData.paciente.condicao_saude_outro;
+
+    // Verifica campos do responsável quando necessário
+    const responsavelError =
+      localData.paciente.possui_responsavel &&
+      (!localData.responsavel.nome_responsavel ||
+        !localData.responsavel.cpf_responsavel ||
+        !localData.responsavel.parentesco ||
+        errors.nome_responsavel ||
+        errors.cpf_responsavel ||
+        errors.parentesco);
+
+    return (
+      hasValidationErrors ||
+      hasMissingFields ||
+      deficiencyError ||
+      healthConditionError ||
+      responsavelError
+    );
+  };
+
+  // Função para validar o nome completo
+  const validateNome = (nome) => {
+    if (!nome) return "Nome é obrigatório";
+    if (nome.length < 5) return "Nome deve ter pelo menos 5 caracteres";
+    if (!/^[A-Za-zÀ-ÖØ-öø-ÿ\s]*$/.test(nome))
+      return "Nome deve conter apenas letras e espaços";
+    if (nome.trim().split(/\s+/).length < 1)
+      return "Por favor, insira o nome completo (nome e sobrenomes)";
+    return "";
+  };
+
+  const validateEmail = (email) => {
+    if (!email || email.trim() === "") return "";
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) return "Digite um e-mail válido";
+    return "";
+  };
+
+  // --- validação de cpf modificada ---
+  const validateCPF = (cpf) => {
+    // caso esteja vazia, retorna válido mas não é obrigatório
+    if (!cpf) return "";
+
+    // Remove caracteres não numéricos
+    const cleanCPF = cpf.replace(/[^\d]/g, "");
+
+    if (cleanCPF.length !== 11) return "CPF deve ter 11 dígitos";
+
+    // Verifica se todos os dígitos são iguais
+    if (/^(\d)\1{10}$/.test(cleanCPF)) return "CPF inválido";
+
+    let sum = 0;
+    let remainder;
+
+    // Primeiro dígito verificador
+    for (let i = 1; i <= 9; i++) {
+      sum = sum + parseInt(cleanCPF.substring(i - 1, i)) * (11 - i);
+    }
+
+    remainder = (sum * 10) % 11;
+    if (remainder === 10 || remainder === 11) remainder = 0;
+    if (remainder !== parseInt(cleanCPF.substring(9, 10)))
+      return "CPF inválido";
+
+    // Segundo dígito
+    sum = 0;
+    for (let i = 1; i <= 10; i++) {
+      sum = sum + parseInt(cleanCPF.substring(i - 1, i)) * (12 - i);
+    }
+
+    remainder = (sum * 10) % 11;
+    if (remainder === 10 || remainder === 11) remainder = 0;
+    if (remainder !== parseInt(cleanCPF.substring(10, 11)))
+      return "CPF inválido";
+
+    return "";
+  };
+
+  const validateDataNascimento = (data) => {
+    if (!data) return "Data de nascimento é obrigatória";
+
+    const dataNascimento = new Date(data);
+    const hoje = new Date();
+
+    if (isNaN(dataNascimento.getTime())) return "Data de nascimento inválida";
+    if (dataNascimento > hoje)
+      return "Data de nascimento não pode ser no futuro";
+
+    return "";
+  };
+
+  const validateEscolaridade = (escolaridade) => {
+    if (!escolaridade) return "Escolaridade é obrigatória";
+    const opcoesValidas = [
+      "Fundamental Incompleto",
+      "Fundamental Completo",
+      "Médio Incompleto",
+      "Médio Completo",
+      "Superior Incompleto",
+      "Superior Completo",
+      "Pós-graduação",
+    ];
+    if (!opcoesValidas.includes(escolaridade))
+      return "Selecione uma opção válida";
+    return "";
+  };
+
+  const validateEstadoCivil = (estadoCivil) => {
+    if (!estadoCivil) return "Estado civil é obrigatório";
+    const opcoesValidas = [
+      "Solteiro(a)",
+      "Casado(a)",
+      "Divorciado(a)",
+      "Viúvo(a)",
+      "União Estável",
+    ];
+    if (!opcoesValidas.includes(estadoCivil))
+      return "Selecione uma opção válida";
+    return "";
+  };
+
+  // Funções de validação para os campos do responsável
+  const validateNomeResponsavel = (nome, possuiResponsavel) => {
+    if (!possuiResponsavel) return "";
+    if (!nome) return "Nome do responsável é obrigatório";
+    if (nome.length < 5)
+      return "Nome do responsável deve ter pelo menos 5 caracteres";
+    if (!/^[A-Za-zÀ-ÖØ-öø-ÿ\s]*$/.test(nome))
+      return "Nome do responsável deve conter apenas letras e espaços";
+    if (nome.trim().split(/\s+/).length < 2)
+      return "Por favor, insira nome e sobrenome do responsável";
+    return "";
+  };
+
+  const validateCPFResponsavel = (cpf, possuiResponsavel) => {
+    if (!possuiResponsavel) return "";
+    if (!cpf) return "CPF do responsável é obrigatório";
+
+    const cleanCPF = cpf.replace(/[^\d]/g, "");
+    if (cleanCPF.length !== 11) return "CPF do responsável deve ter 11 dígitos";
+    if (/^(\d)\1{10}$/.test(cleanCPF)) return "CPF do responsável inválido";
+
+    let sum = 0;
+    let remainder;
+    for (let i = 1; i <= 9; i++)
+      sum = sum + parseInt(cleanCPF.substring(i - 1, i)) * (11 - i);
+    remainder = (sum * 10) % 11;
+    if (remainder === 10 || remainder === 11) remainder = 0;
+    if (remainder !== parseInt(cleanCPF.substring(9, 10)))
+      return "CPF do responsável inválido";
+
+    sum = 0;
+    for (let i = 1; i <= 10; i++)
+      sum = sum + parseInt(cleanCPF.substring(i - 1, i)) * (12 - i);
+    remainder = (sum * 10) % 11;
+    if (remainder === 10 || remainder === 11) remainder = 0;
+    if (remainder !== parseInt(cleanCPF.substring(10, 11)))
+      return "CPF do responsável inválido";
+
+    return "";
+  };
+
+  const validateParentesco = (parentesco, possuiResponsavel) => {
+    if (!possuiResponsavel) return "";
+    if (!parentesco) return "Selecione o parentesco do responsável";
+    const opcoesValidas = [
+      "mae",
+      "pai",
+      "avo",
+      "tia",
+      "tio",
+      "irma",
+      "irmao",
+      "outro",
+    ];
+    if (!opcoesValidas.includes(parentesco))
+      return "Selecione uma opção válida de parentesco";
+    return "";
+  };
+
   // Função para atualizar os estados locais
   const handleChange = (e, defaultValue = null, scope = "paciente") => {
     const { name, value, type, checked } = e.target;
 
-    const newValue = type === "checkbox"
-      ? checked
-      : type === "radio" && defaultValue !== null
-      ? defaultValue === "Sim"
-      : defaultValue ?? value;
+    const newValue =
+      type === "checkbox"
+        ? checked
+        : type === "radio" && defaultValue !== null
+        ? defaultValue === "Sim"
+        : defaultValue ?? value;
 
     setLocalData((prev) => ({
       ...prev,
@@ -333,88 +317,70 @@ export default function CadastroPaciente() {
 
     // Validações específicas para cada campo
     if (name === "nome") {
-      const error = validateNome(value);
-      setErrors(prev => ({
-        ...prev,
-        nome: error
-      }));
+      setErrors((prev) => ({ ...prev, nome: validateNome(value) }));
     } else if (name === "email") {
-      const error = validateEmail(value);
-      setErrors(prev => ({
-        ...prev,
-        email: error
-      }));
-    // } else if (name === "cpf") {
-    //   const error = validateCPF(value);
-    //   setErrors(prev => ({
-    //     ...prev,
-    //     cpf: error
-    //   }));
+      setErrors((prev) => ({ ...prev, email: validateEmail(value) }));
+    } else if (name === "cpf") {
+      // --- REATIVADO: Validação do CPF do paciente ---
+      setErrors((prev) => ({ ...prev, cpf: validateCPF(value) }));
     } else if (name === "data_nascimento") {
-      const error = validateDataNascimento(value);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        data_nascimento: error
+        data_nascimento: validateDataNascimento(value),
       }));
     } else if (name === "escolaridade") {
-      const error = validateEscolaridade(value);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        escolaridade: error
+        escolaridade: validateEscolaridade(value),
       }));
     } else if (name === "estado_civil") {
-      const error = validateEstadoCivil(value);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        estado_civil: error
+        estado_civil: validateEstadoCivil(value),
       }));
-    // } else if (name === "condicao_saude" || name === "condicao_saude_outro") {
-    //   const error = validateCondicaoSaude(
-    //     name === "condicao_saude" ? value : localData.paciente.condicao_saude,
-    //     name === "condicao_saude_outro" ? value : localData.paciente.condicao_saude_outro
-    //   );
-    //   setErrors(prev => ({
-    //     ...prev,
-    //     condicao_saude: error
-    //   }));
-    // } else if (name === "possui_deficiencia" || name === "deficiencia") {
-    //   const error = validateDeficiencia(
-    //     name === "possui_deficiencia" ? value === "Sim" : localData.paciente.possui_deficiencia,
-    //     name === "deficiencia" ? value : localData.paciente.deficiencia
-    //   );
-    //   setErrors(prev => ({
-    //     ...prev,
-    //     deficiencia: error
-    //   }));
     } else if (name === "nome_responsavel") {
-      const error = validateNomeResponsavel(value, localData.paciente.possui_responsavel);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        nome_responsavel: error
+        nome_responsavel: validateNomeResponsavel(
+          value,
+          localData.paciente.possui_responsavel
+        ),
       }));
     } else if (name === "cpf_responsavel") {
-      const error = validateCPFResponsavel(value, localData.paciente.possui_responsavel);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        cpf_responsavel: error
+        cpf_responsavel: validateCPFResponsavel(
+          value,
+          localData.paciente.possui_responsavel
+        ),
       }));
     } else if (name === "parentesco") {
-      const error = validateParentesco(value, localData.paciente.possui_responsavel);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
-        parentesco: error
+        parentesco: validateParentesco(
+          value,
+          localData.paciente.possui_responsavel
+        ),
       }));
     } else if (name === "possui_responsavel") {
-      // Quando mudar possui_responsavel, validar todos os campos do responsável
-      const nomeResponsavelError = validateNomeResponsavel(localData.responsavel.nome_responsavel, value === "Sim");
-      const cpfResponsavelError = validateCPFResponsavel(localData.responsavel.cpf_responsavel, value === "Sim");
-      const parentescoError = validateParentesco(localData.responsavel.parentesco, value === "Sim");
-      
-      setErrors(prev => ({
+      const nomeResponsavelError = validateNomeResponsavel(
+        localData.responsavel.nome_responsavel,
+        value === "Sim"
+      );
+      const cpfResponsavelError = validateCPFResponsavel(
+        localData.responsavel.cpf_responsavel,
+        value === "Sim"
+      );
+      const parentescoError = validateParentesco(
+        localData.responsavel.parentesco,
+        value === "Sim"
+      );
+
+      setErrors((prev) => ({
         ...prev,
         nome_responsavel: nomeResponsavelError,
         cpf_responsavel: cpfResponsavelError,
-        parentesco: parentescoError
+        parentesco: parentescoError,
       }));
     }
   };
@@ -422,24 +388,22 @@ export default function CadastroPaciente() {
   // Função para salvar na mochila
   const handleSubmit = (e) => {
     e.preventDefault();
-    
+
     // Validar todos os campos obrigatórios
     const nomeError = validateNome(localData.paciente.nome);
     const emailError = validateEmail(localData.paciente.email);
-    // const cpfError = validateCPF(localData.paciente.cpf);
-    const dataNascimentoError = validateDataNascimento(localData.paciente.data_nascimento);
-    const escolaridadeError = validateEscolaridade(localData.paciente.escolaridade);
-    const estadoCivilError = validateEstadoCivil(localData.paciente.estado_civil);
-    // const condicaoSaudeError = validateCondicaoSaude(
-    //   localData.paciente.condicao_saude,
-    //   localData.paciente.condicao_saude_outro
-    // );
-    // const deficienciaError = validateDeficiencia(
-    //   localData.paciente.possui_deficiencia,
-    //   localData.paciente.deficiencia
-    // );
+    const cpfError = validateCPF(localData.paciente.cpf); // <-- VALIDAÇÃO DO CPF
+    const dataNascimentoError = validateDataNascimento(
+      localData.paciente.data_nascimento
+    );
+    const escolaridadeError = validateEscolaridade(
+      localData.paciente.escolaridade
+    );
+    const estadoCivilError = validateEstadoCivil(
+      localData.paciente.estado_civil
+    );
 
-    // Validações do responsável (apenas se possui_responsavel for true)
+    // Validações do responsável
     const nomeResponsavelError = validateNomeResponsavel(
       localData.responsavel.nome_responsavel,
       localData.paciente.possui_responsavel
@@ -453,37 +417,37 @@ export default function CadastroPaciente() {
       localData.paciente.possui_responsavel
     );
 
-    setErrors(prev => ({
+    setErrors((prev) => ({
       ...prev,
       nome: nomeError,
       email: emailError,
-      // cpf: cpfError,
+      cpf: cpfError,
       data_nascimento: dataNascimentoError,
       escolaridade: escolaridadeError,
       estado_civil: estadoCivilError,
-      // condicao_saude: condicaoSaudeError,
-      // deficiencia: deficienciaError,
       nome_responsavel: nomeResponsavelError,
       cpf_responsavel: cpfResponsavelError,
-      parentesco: parentescoError
+      parentesco: parentescoError,
     }));
 
     // Se houver qualquer erro, não prossegue
-    if (nomeError || emailError || dataNascimentoError || 
-        escolaridadeError || estadoCivilError || 
-        (localData.paciente.possui_responsavel && (nomeResponsavelError || cpfResponsavelError || parentescoError))) {
+    // (O CPF só dará erro aqui se validateCPF retornar string não vazia)
+    if (
+      nomeError ||
+      emailError ||
+      cpfError ||
+      dataNascimentoError ||
+      escolaridadeError ||
+      estadoCivilError ||
+      (localData.paciente.possui_responsavel &&
+        (nomeResponsavelError || cpfResponsavelError || parentescoError))
+    ) {
       return;
     }
 
     updateFormData(localData);
     console.log("Dados após atualização do contexto:", localData);
-    // try {
-    //   const response = axios.post("https://portaligrejaback.siaeserver.com/api/pacientes/create", localData)
-    //   console.log("Resposta do servidor:", response.data);
 
-    // } catch (error) {
-    //   console.error("Erro ao enviar dados do paciente:", error);
-    // }
     navigate("/second-page-paciente");
   };
 
@@ -493,109 +457,163 @@ export default function CadastroPaciente() {
 
       <main className="flex-grow flex flex-col items-center gap-8 py-10 px-4 sm:px-6">
         <div className="w-full max-w-[1344px] flex flex-col sm:flex-row justify-center items-center gap-4 text-center sm:text-left">
-          <img src={Logo} alt="Logo da Instituição" className="h-[70px] w-[70px] sm:h-[90px] sm:w-[90px]" />
-          <h2 className="font-bold text-[#060F2A] text-2xl sm:text-3xl lg:text-4xl">Sistema Integrado de Atendimento</h2>
+          <img
+            src={Logo}
+            alt="Logo da Instituição"
+            className="h-[70px] w-[70px] sm:h-[90px] sm:w-[90px]"
+          />
+          <h2 className="font-bold text-[#060F2A] text-2xl sm:text-3xl lg:text-4xl">
+            Sistema Integrado de Atendimento
+          </h2>
         </div>
 
-        {/* Card Principal do Formulário */}
         <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-[0_8px_16px_rgba(113,146,255,0.25)] p-6 md:p-12">
           <div className="text-center mb-8">
-            <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">Cadastro de Paciente/Responsável</h3>
-            <h5 className="text-[#0A1B4B] font-normal text-[16px] mt-4">Atendimento social, jurídico e de saúde, rápido e integrado.</h5>
+            <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">
+              Cadastro de Paciente/Responsável
+            </h3>
+            <h5 className="text-[#0A1B4B] font-normal text-[16px] mt-4">
+              Atendimento social, jurídico e de saúde, rápido e integrado.
+            </h5>
           </div>
-          <div className="flex items-center justify-center mb-10">{/* ... Stepper ... */}</div>
+          <div className="flex items-center justify-center mb-10">
+            {/* ... Stepper ... */}
+          </div>
 
           <form className="space-y-10" onSubmit={handleSubmit}>
-            {/* Seção: Dados Pessoais */}
             <section>
-              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">Dados Pessoais</h3>
+              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+                Dados Pessoais
+              </h3>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <FormField 
-                  label="Nome completo" 
-                  id="nome" 
-                  placeholder="Abimael Barros Castro Denifrer" 
-                  colSpan="md:col-span-3" 
-                  value={localData.paciente.nome} 
-                  onChange={(e) => handleChange(e, null, "paciente")} 
+                <FormField
+                  label="Nome completo"
+                  id="nome"
+                  placeholder="Abimael Barros Castro Denifrer"
+                  colSpan="md:col-span-3"
+                  value={localData.paciente.nome}
+                  onChange={(e) => handleChange(e, null, "paciente")}
                   error={errors.nome}
                   required={true}
                   helperText="Digite seu nome completo (nome e sobrenomes)"
                 />
-                <FormField 
-                  label="Data de nascimento" 
-                  id="data_nascimento" 
-                  placeholder="DD/MM/AAAA" 
-                  type="date" 
-                  value={localData.paciente.data_nascimento} 
+                <FormField
+                  label="Data de nascimento"
+                  id="data_nascimento"
+                  placeholder="DD/MM/AAAA"
+                  type="date"
+                  value={localData.paciente.data_nascimento}
                   onChange={(e) => handleChange(e, null, "paciente")}
                   error={errors.data_nascimento}
                   required={true}
                   helperText="Informe sua data de nascimento"
                 />
-                <FormField 
-                  label="CPF" 
-                  id="cpf" 
-                  placeholder="000.000.000-00" 
-                  value={localData.paciente.cpf} 
+
+               {/* campo alterado */}
+                <FormField
+                  label="CPF"
+                  id="cpf"
+                  placeholder="000.000.000-00"
+                  value={localData.paciente.cpf}
                   onChange={(e) => handleChange(e, null, "paciente")}
                   error={errors.cpf}
-                  helperText="Digite um CPF válido"
+                  helperText="Opcional. Se preencher, digite um CPF válido"
                 />
-                <FormField label="Telefone / Whatsapp" id="telefone" placeholder="(98) 9 1234-5678" value={localData.paciente.telefone} onChange={(e) => handleChange(e, null, "paciente")} />
+
+          
+                <FormField
+                  label="Telefone / Whatsapp"
+                  id="telefone"
+                  placeholder="(98) 9 1234-5678"
+                  value={localData.paciente.telefone}
+                  onChange={(e) => handleChange(e, null, "paciente")}
+                />
+
+              
                 <div className="md:col-span-1">
                   <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
                     <h4>Sexo</h4>
                   </label>
                   <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mt-2">
                     <label className="flex items-center">
-                      <input type="radio" name="sexo" value="Masculino" checked={localData.paciente.sexo === "Masculino"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Masculino
+                      <input
+                        type="radio"
+                        name="sexo"
+                        value="Masculino"
+                        checked={localData.paciente.sexo === "Masculino"}
+                        onChange={(e) => handleChange(e, null, "paciente")}
+                        className="mr-2 w-[24px] h-[24px]"
+                      />{" "}
+                      Masculino
                     </label>
                     <label className="flex items-center">
-                      <input type="radio" name="sexo" value="Feminino" checked={localData.paciente.sexo === "Feminino"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Feminino
+                      <input
+                        type="radio"
+                        name="sexo"
+                        value="Feminino"
+                        checked={localData.paciente.sexo === "Feminino"}
+                        onChange={(e) => handleChange(e, null, "paciente")}
+                        className="mr-2 w-[24px] h-[24px]"
+                      />{" "}
+                      Feminino
                     </label>
                   </div>
                 </div>
+
                 <div className="md:col-span-1">
                   <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1 flex">
-                    <h4>Escolaridade <span className="text-red-500">*</span></h4> 
+                    <h4>
+                      Escolaridade <span className="text-red-500">*</span>
+                    </h4>
                   </label>
-                  <select 
-                    name="escolaridade" 
-                    value={localData.paciente.escolaridade} 
-                    onChange={(e) => handleChange(e, null, "paciente")} 
+                  <select
+                    name="escolaridade"
+                    value={localData.paciente.escolaridade}
+                    onChange={(e) => handleChange(e, null, "paciente")}
                     className={`w-full mt-2 px-4 py-2 border rounded-lg focus:ring-blue-500 focus:border-blue-500 ${
-                      errors.escolaridade ? 'border-red-500' : 'border-gray-300'
+                      errors.escolaridade ? "border-red-500" : "border-gray-300"
                     }`}
                   >
                     <option value="">Selecione</option>
-                    <option value="Fundamental Incompleto">Fundamental Incompleto</option>
-                    <option value="Fundamental Completo">Fundamental Completo</option>
+                    <option value="Fundamental Incompleto">
+                      Fundamental Incompleto
+                    </option>
+                    <option value="Fundamental Completo">
+                      Fundamental Completo
+                    </option>
                     <option value="Médio Incompleto">Médio Incompleto</option>
                     <option value="Médio Completo">Médio Completo</option>
-                    <option value="Superior Incompleto">Superior Incompleto</option>
+                    <option value="Superior Incompleto">
+                      Superior Incompleto
+                    </option>
                     <option value="Superior Completo">Superior Completo</option>
                     <option value="Pós-graduação">Pós-graduação</option>
                   </select>
                   <div className="min-h-[1.25rem] mt-1">
                     {errors.escolaridade ? (
-                      <p className="text-sm text-red-600">{errors.escolaridade}</p>
+                      <p className="text-sm text-red-600">
+                        {errors.escolaridade}
+                      </p>
                     ) : (
-                      <p className="text-[15px] text-[#0F276D] font-semibold">Selecione seu nível de escolaridade</p>
+                      <p className="text-[15px] text-[#0F276D] font-semibold">
+                        Selecione seu nível de escolaridade
+                      </p>
                     )}
                   </div>
                 </div>
 
-                {/* Campo: Estado Civil */}
                 <div className="md:col-span-1">
                   <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1 flex">
-                    <h4>Estado Civil <span className="text-red-500">*</span> </h4> 
+                    <h4>
+                      Estado Civil <span className="text-red-500">*</span>{" "}
+                    </h4>
                   </label>
-                  <select 
-                    name="estado_civil" 
-                    value={localData.paciente.estado_civil} 
-                    onChange={(e) => handleChange(e, null, "paciente")} 
+                  <select
+                    name="estado_civil"
+                    value={localData.paciente.estado_civil}
+                    onChange={(e) => handleChange(e, null, "paciente")}
                     className={`w-full mt-2 px-4 py-2 border rounded-lg focus:ring-blue-500 focus:border-blue-500 ${
-                      errors.estado_civil ? 'border-red-500' : 'border-gray-300'
+                      errors.estado_civil ? "border-red-500" : "border-gray-300"
                     }`}
                   >
                     <option value="">Selecione</option>
@@ -607,203 +625,148 @@ export default function CadastroPaciente() {
                   </select>
                   <div className="min-h-[1.25rem] mt-1">
                     {errors.estado_civil ? (
-                      <p className="text-sm text-red-600">{errors.estado_civil}</p>
+                      <p className="text-sm text-red-600">
+                        {errors.estado_civil}
+                      </p>
                     ) : (
-                      <p className="text-[15px] text-[#0F276D] font-semibold">Selecione seu estado civil</p>
+                      <p className="text-[15px] text-[#0F276D] font-semibold">
+                        Selecione seu estado civil
+                      </p>
                     )}
                   </div>
                 </div>
 
-                <FormField 
-                  label="E-mail" 
-                  id="email" 
-                  type="email" 
-                  placeholder="email@exemplo.com" 
-                  colSpan="md:col-span-2" 
-                  value={localData.paciente.email} 
+                <FormField
+                  label="E-mail"
+                  id="email"
+                  type="email"
+                  placeholder="email@exemplo.com"
+                  colSpan="md:col-span-2"
+                  value={localData.paciente.email}
                   onChange={(e) => handleChange(e, null, "paciente")}
                   error={errors.email}
                   helperText="Digite um e-mail válido"
                 />
+
+                {/* Bloco Responsável */}
                 <div>
                   <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-2">
                     <h4>Possui Responsável?</h4>
                   </label>
                   <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
                     <label className="flex items-center">
-                      <input type="radio" name="possui_responsavel" value="Sim" checked={localData.paciente.possui_responsavel === true} onChange={(e) => handleChange(e, "Sim", "paciente")} className="mr-2 w-[24px] h-[24px]" /> Sim
+                      <input
+                        type="radio"
+                        name="possui_responsavel"
+                        value="Sim"
+                        checked={localData.paciente.possui_responsavel === true}
+                        onChange={(e) => handleChange(e, "Sim", "paciente")}
+                        className="mr-2 w-[24px] h-[24px]"
+                      />{" "}
+                      Sim
                     </label>
                     <label className="flex items-center">
-                      <input type="radio" name="possui_responsavel" value="Não" checked={localData.paciente.possui_responsavel === false} onChange={(e) => handleChange(e, "Não", "paciente")} className="mr-2 w-[24px] h-[24px]" /> Não
+                      <input
+                        type="radio"
+                        name="possui_responsavel"
+                        value="Não"
+                        checked={
+                          localData.paciente.possui_responsavel === false
+                        }
+                        onChange={(e) => handleChange(e, "Não", "paciente")}
+                        className="mr-2 w-[24px] h-[24px]"
+                      />{" "}
+                      Não
                     </label>
                   </div>
                 </div>
               </div>
             </section>
+
             {localData.paciente.possui_responsavel && (
               <section className="mt-8 p-6 bg-gray-100 rounded-xl border border-gray-300">
-                <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">Dados do Responsável</h3>
-
+                <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">
+                  Dados do Responsável
+                </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {/* Nome */}
-                  <FormField label="Nome completo do responsável" id="nome_responsavel" placeholder="Ex: Maria da Silva" value={localData.responsavel.nome_responsavel} onChange={(e) => handleChange(e, null, "responsavel")} error={errors.nome_responsavel} helperText="Digite o nome completo (nome e sobrenome)"/>
+                  <FormField
+                    label="Nome completo do responsável"
+                    id="nome_responsavel"
+                    placeholder="Ex: Maria da Silva"
+                    value={localData.responsavel.nome_responsavel}
+                    onChange={(e) => handleChange(e, null, "responsavel")}
+                    error={errors.nome_responsavel}
+                    helperText="Digite o nome completo (nome e sobrenome)"
+                  />
+                  <FormField
+                    label="CPF do responsável"
+                    id="cpf_responsavel"
+                    placeholder="000.000.000-00"
+                    value={localData.responsavel.cpf_responsavel}
+                    onChange={(e) => handleChange(e, null, "responsavel")}
+                    error={errors.cpf_responsavel}
+                    helperText="Digite um CPF válido"
+                  />
+                  <FormField
+                    label="Telefone do responsável"
+                    id="telefone_responsavel"
+                    placeholder="(00) 00000-0000"
+                    value={localData.responsavel.telefone_responsavel}
+                    onChange={(e) => handleChange(e, null, "responsavel")}
+                  />
 
-                  {/* CPF */}
-                  <FormField label="CPF do responsável" id="cpf_responsavel" placeholder="000.000.000-00" value={localData.responsavel.cpf_responsavel} onChange={(e) => handleChange(e, null, "responsavel")} error={errors.cpf_responsavel} helperText="Digite um CPF válido"/>
-
-                  {/* Telefone */}
-                  <FormField label="Telefone do responsável" id="telefone_responsavel" placeholder="(00) 00000-0000" value={localData.responsavel.telefone_responsavel} onChange={(e) => handleChange(e, null, "responsavel")}/>
-
-                  {/* Parentesco - agora como SELECT */}
                   <div className="md:col-span-1">
                     <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
                       <h4>Parentesco</h4>
                     </label>
-                    <select name="parentesco" value={localData.responsavel.parentesco} onChange={(e) => handleChange(e, null, "responsavel")} className="w-full  px-4 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500">
+                    <select
+                      name="parentesco"
+                      value={localData.responsavel.parentesco}
+                      onChange={(e) => handleChange(e, null, "responsavel")}
+                      className="w-full  px-4 py-2 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
+                    >
                       <option value="">Selecione</option>
                       <option value="mae">Mãe</option>
                       <option value="pai">Pai</option>
-                      <option value="avo">Avó</option>
-                      <option value="avo">Avô</option>
-                      <option value="tia">Tia</option>
-                      <option value="tio">Tio</option>
-                      <option value="irma">Irmã</option>
-                      <option value="irmao">Irmão</option>
+                      <option value="avo">Avó/Avô</option>
+                      <option value="tia">Tia/Tio</option>
+                      <option value="irma">Irmã/Irmão</option>
                       <option value="outro">Outro</option>
                     </select>
                     <div className="min-h-[1.25rem] mt-1">
-                    {errors.estado_civil ? (
-                      <p className="text-sm text-red-600">{errors.estado_civil}</p>
-                    ) : (
-                      <p className="text-[15px] text-[#0F276D] font-semibold">Selecione o tipo de parentesco</p>
-                    )}
-                  </div>
+                      {errors.parentesco ? (
+                        <p className="text-sm text-red-600">
+                          {errors.parentesco}
+                        </p>
+                      ) : (
+                        <p className="text-[15px] text-[#0F276D] font-semibold">
+                          Selecione o tipo de parentesco
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </section>
             )}
 
-            {/* Seção: Informações de Saúde */}
-            {/* <section>
-              <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B] mb-6 text-center">Informações Básicas de Saúde</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-                <div>
-                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-2 flex">
-                    <h4>Você possui alguma condição de saúde importante? <span className="text-red-500">*</span></h4>
-              
-                  </label>
-                  <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-                    <label className="flex items-center">
-                      <input type="radio" name="condicao_saude" value="Diabetes" checked={localData.paciente.condicao_saude === "Diabetes"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Diabetes
-                    </label>
-                    <label className="flex items-center">
-                      <input type="radio" name="condicao_saude" value="Hipertensão" checked={localData.paciente.condicao_saude === "Hipertensão"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Hipertensão
-                    </label>
-                    <label className="flex items-center">
-                      <input type="radio" name="condicao_saude" value="Alergia" checked={localData.paciente.condicao_saude === "Alergia"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Alergia
-                    </label>
-                    <label className="flex items-center">
-                      <input type="radio" name="condicao_saude" value="Nenhuma" checked={localData.paciente.condicao_saude === "Nenhuma"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Nenhuma
-                    </label>
-                    <label className="flex items-center">
-                      <input type="radio" name="condicao_saude" value="Outro" checked={localData.paciente.condicao_saude === "Outro"} onChange={(e) => handleChange(e, null, "paciente")} className="mr-2 w-[24px] h-[24px]" /> Outro
-                    </label>
-                  </div>
-                  {localData.paciente.condicao_saude === "Outro" && (
-                    <input 
-                      type="text" 
-                      name="condicao_saude_outro" 
-                      placeholder="Especifique sua condição de saúde" 
-                      className={`w-full mt-2 px-4 py-2 border rounded-lg ${
-                        errors.condicao_saude ? 'border-red-500' : 'border-gray-300'
-                      }`}
-                      value={localData.paciente.condicao_saude_outro} 
-                      onChange={(e) => handleChange(e, null, "paciente")} 
-                    />
-                  )}
-                  <div className="min-h-[1.25rem] mt-1">
-                    {errors.condicao_saude ? (
-                      <p className="text-sm text-red-600">{errors.condicao_saude}</p>
-                    ) : (
-                      <p className="text-[15px] text-[#0F276D] font-semibold">Selecione sua condição de saúde</p>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-2 flex">
-                    <h4>Possui alguma deficiência? <span className="text-red-500">*</span></h4>
-                    
-                  </label>
-                  <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-                    <label className="flex items-center">
-                      <input 
-                        type="radio" 
-                        name="possui_deficiencia" 
-                        value="Sim" 
-                        checked={localData.paciente.possui_deficiencia === true} 
-                        onChange={(e) => handleChange(e, "Sim", "paciente")} 
-                        className="mr-2 w-[24px] h-[24px]" 
-                      /> Sim
-                    </label>
-                    <label className="flex items-center">
-                      <input 
-                        type="radio" 
-                        name="possui_deficiencia" 
-                        value="Não" 
-                        checked={localData.paciente.possui_deficiencia === false} 
-                        onChange={(e) => handleChange(e, "Não", "paciente")} 
-                        className="mr-2 w-[24px] h-[24px]" 
-                      /> Não
-                    </label>
-                  </div>
-                  {localData.paciente.possui_deficiencia && (
-                    <input 
-                      type="text" 
-                      name="deficiencia" 
-                      placeholder="Especifique qual é a deficiência" 
-                      className={`w-full mt-2 px-4 py-2 border rounded-lg ${
-                        errors.deficiencia ? 'border-red-500' : 'border-gray-300'
-                      }`}
-                      value={localData.paciente.deficiencia} 
-                      onChange={(e) => handleChange(e, null, "paciente")} 
-                    />
-                  )}
-                  <div className="min-h-[1.25rem] mt-1">
-                    {errors.deficiencia ? (
-                      <p className="text-sm text-red-600">{errors.deficiencia}</p>
-                    ) : (
-                      localData.paciente.possui_deficiencia && (
-                        <p className="text-[15px] text-[#0F276D]">Descreva a deficiência de forma clara e objetiva</p>
-                      )
-                    )}
-                  </div>
-                </div>
-                <div className="md:col-span-2">
-                  <label htmlFor="observacoes" className="block text-sm font-semibold text-gray-700 mb-1">
-                    OBSERVAÇÕES (Se desejar):
-                  </label>
-                  <textarea id="observacoes" name="observacoes" rows="4" placeholder="Por exemplo: Cadastro individual." className="w-full mt-1 px-4 py-2 border border-gray-300 rounded-lg" value={localData.paciente.observacoes} onChange={(e) => handleChange(e, null, "paciente")}></textarea>
-                </div>
-              </div>
-            </section> */}
-
-            {/* Botões de Ação */}
             <div className="flex justify-center items-center pt-6 border-t">
               <div className="flex flex-col lg:flex-row justify-center items-center w-full gap-4 lg:gap-[24px]">
-                <button 
-                  type="submit" 
+                <button
+                  type="submit"
                   disabled={hasFormErrors()}
                   className={`w-full lg:w-[612px] h-[56px] flex justify-center items-center font-bold text-lg rounded-[5px] transition-all duration-300 ${
                     hasFormErrors()
-                      ? 'bg-gray-300 text-gray-500 border-gray-300 cursor-not-allowed'
-                      : 'bg-white text-[#193FB0] border border-[#193FB0] shadow-[0_8px_16px_rgba(113,146,255,0.25)] hover:bg-[#193FB0] hover:text-white'
+                      ? "bg-gray-300 text-gray-500 border-gray-300 cursor-not-allowed"
+                      : "bg-white text-[#193FB0] border border-[#193FB0] shadow-[0_8px_16px_rgba(113,146,255,0.25)] hover:bg-[#193FB0] hover:text-white"
                   }`}
                 >
-                  {hasFormErrors() ? 'Preencha todos os campos obrigatórios' : 'Salvar Cadastro e prosseguir'}
+                  {hasFormErrors()
+                    ? "Preencha todos os campos obrigatórios"
+                    : "Salvar Cadastro e prosseguir"}
                 </button>
-                <button 
-                  type="button" 
-                  className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#BE3E1A] font-bold text-lg border border-[#BE3E1A] rounded-[5px] hover:bg-[#BE3E1A] hover:text-white transition-all duration-300" 
+                <button
+                  type="button"
+                  className="w-full lg:w-[612px] h-[56px] flex justify-center items-center bg-white text-[#BE3E1A] font-bold text-lg border border-[#BE3E1A] rounded-[5px] hover:bg-[#BE3E1A] hover:text-white transition-all duration-300"
                   onClick={() => navigate("/")}
                 >
                   Cancelar
@@ -811,7 +774,9 @@ export default function CadastroPaciente() {
               </div>
             </div>
 
-            <h6 className="text-center font-bold text-[16px] text-[#0A1B4B]">Suas informações são confidenciais e protegidas.</h6>
+            <h6 className="text-center font-bold text-[16px] text-[#0A1B4B]">
+              Suas informações são confidenciais e protegidas.
+            </h6>
           </form>
         </div>
       </main>

--- a/src/Pages/CadastroPacientes3.jsx
+++ b/src/Pages/CadastroPacientes3.jsx
@@ -8,45 +8,7 @@ import FormCadastroLayout from "../components/FormCadastroLayout";
 import axios from "../services/axios.js"
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-
-const FormField = ({
-  label,
-  id,
-  type = "text",
-  placeholder,
-  colSpan = "col-span-1",
-  value,
-  onChange,
-  error,
-  required = false,
-  helperText,
-}) => {
-  const showError = Boolean(error);
-  return (
-    <div className={colSpan}>
-      <label htmlFor={id} className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      {helperText && !showError && <p className="text-xs text-gray-500 mb-1">{helperText}</p>}
-      <input
-        type={type}
-        id={id}
-        name={id}
-        placeholder={placeholder}
-        className={`w-full px-4 py-2 border rounded-2xl focus:ring-blue-500 focus:border-blue-500 ${showError ? 'border-red-500' : 'border-gray-300'}`}
-        value={value}
-        onChange={onChange}
-      />
-      <div className="min-h-[1.25rem] mt-1">
-        {showError ? (
-          <p className="text-sm text-red-600">{error}</p>
-        ) : (
-          helperText && <p className="text-[15px] text-[#0F276D] font-semibold">{helperText}</p>
-        )}
-      </div>
-    </div>
-  );
-};
+import FormField from "../components/FormField";
 
 export default function CadastroPaciente3() {
   const navigate = useNavigate();
@@ -178,63 +140,63 @@ export default function CadastroPaciente3() {
             />
 
             <div>
-              <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-2">
+              <label className="block text-lg md:text-[20px] font-bold text-azul-principal mb-2">
                 Situação Empregatícia:
               </label>
 
               <div className="flex flex-row flex-wrap gap-x-8 gap-y-4 pt-2">
-                <label className="flex items-center text-[#0F276D]">
+                <label className="flex items-center text-azul-principal">
                   <input
                     type="radio"
                     name="situacao_empregaticia"
                     value="Empregado"
                     checked={localData.situacao_empregaticia === "Empregado"}
                     onChange={handleChange}
-                    className="mr-2 w-5 h-5"
+                    className="mr-2 w-5 h-5 text-azul-botao focus:ring-azul-botao"
                   />
                   Empregado
                 </label>
-                <label className="flex items-center text-[#0F276D]">
+                <label className="flex items-center text-azul-principal">
                   <input
                     type="radio"
                     name="situacao_empregaticia"
                     value="Desempregado"
                     checked={localData.situacao_empregaticia === "Desempregado"}
                     onChange={handleChange}
-                    className="mr-2 w-5 h-5"
+                    className="mr-2 w-5 h-5 text-azul-botao focus:ring-azul-botao"
                   />
                   Desempregado
                 </label>
-                <label className="flex items-center text-[#0F276D]">
+                <label className="flex items-center text-azul-principal">
                   <input
                     type="radio"
                     name="situacao_empregaticia"
                     value="Autônomo"
                     checked={localData.situacao_empregaticia === "Autônomo"}
                     onChange={handleChange}
-                    className="mr-2 w-5 h-5"
+                    className="mr-2 w-5 h-5 text-azul-botao focus:ring-azul-botao"
                   />
                   Autônomo
                 </label>
-                <label className="flex items-center text-[#0F276D]">
+                <label className="flex items-center text-azul-principal">
                   <input
                     type="radio"
                     name="situacao_empregaticia"
                     value="Aposentado"
                     checked={localData.situacao_empregaticia === "Aposentado"}
                     onChange={handleChange}
-                    className="mr-2 w-5 h-5"
+                    className="mr-2 w-5 h-5 text-azul-botao focus:ring-azul-botao"
                   />
                   Aposentado
                 </label>
-                <label className="flex items-center text-[#0F276D]">
+                <label className="flex items-center text-azul-principal">
                   <input
                     type="radio"
                     name="situacao_empregaticia"
                     value="Outro"
                     checked={localData.situacao_empregaticia === "Outro"}
                     onChange={handleChange}
-                    className="mr-2 w-5 h-5"
+                    className="mr-2 w-5 h-5 text-azul-botao focus:ring-azul-botao"
                   />
                   Outro
                 </label>

--- a/src/Pages/SecondPagePaciente.jsx
+++ b/src/Pages/SecondPagePaciente.jsx
@@ -6,38 +6,7 @@ import Header from "../components/Header";
 import Footer from "../components/Footer";
 import FormCadastroLayout from "../components/FormCadastroLayout";
 import axios from "../services/axios.js";
-
-const FormField = ({ label, id, type = "text", placeholder, colSpan = "col-span-1", helperText, value, onChange, error, required = false, showHelper = true }) => {
-  const showError = Boolean(error);
-  return (
-    <div className={colSpan}>
-      <label htmlFor={id} className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
-        {label} {required && <span className="text-red-500">*</span>}
-      </label>
-      <input
-        type={type}
-        id={id}
-        name={id}
-        placeholder={placeholder}
-        className={`w-full px-4 py-2 border rounded-lg focus:ring-blue-500 focus:border-blue-500 ${
-          showError ? 'border-red-500' : 'border-gray-300'
-        }`}
-        value={value}
-        onChange={onChange}
-      />
-      {/* Espaço fixo para helper/erro */}
-      <div className="min-h-[1.25rem] mt-1">
-        {showError ? (
-          <p className="text-sm text-red-600">{error}</p>
-        ) : (
-          showHelper && (
-            <p className="text-[15px] text-[#0F276D] font-semibold">{helperText}</p>
-          )
-        )}
-      </div>
-    </div>
-  );
-};
+import FormField from "../components/FormField";
 
 export default function SecondPagePaciente() {
   const navigate = useNavigate();
@@ -286,10 +255,10 @@ export default function SecondPagePaciente() {
             />
             {/* Campo: Estado */}
             <div className="md:col-span-1">
-              <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
+              <label className="block text-lg md:text-[20px] text-azul-principal font-bold  mb-1">
                 <h4>Estado</h4>
               </label>
-              <select id="estado" name="estado" value={localData.estado} onChange={handleChange} className={`w-full px-4 py-2 border rounded-lg bg-white focus:ring-blue-500 focus:border-blue-500 ${errors.estado ? 'border-red-500' : 'border-gray-300'}`}>
+              <select id="estado" name="estado" value={localData.estado} onChange={handleChange} className={`w-full px-4 py-2 border rounded-lg bg-white outline-none transition-all duration-200 focus:ring-2 focus:ring-azul-botao focus:border-transparent ${errors.estado ? 'border-red-500' : 'border-gray-300'}`}>
                 <option value="">Selecione o Estado</option>
                 {estados.map((uf) => (
                   <option key={uf.id} value={uf.id}>
@@ -301,17 +270,17 @@ export default function SecondPagePaciente() {
                 {errors.estado ? (
                   <p className="text-sm text-red-600">{errors.estado}</p>
                 ) : (
-                  <p className="text-[15px] text-[#0F276D] font-semibold">Selecione o estado</p>
+                  <p className="text-[15px] text-azul-principal font-semibold">Selecione o estado</p>
                 )}
               </div>
             </div>
 
             {/* Campo: Cidade */}
             <div className="md:col-span-1">
-              <label className="block text-lg md:text-[20px] font-bold text-[#0F276D] mb-1">
+              <label className="block text-lg md:text-[20px] font-bold text-azul-principal mb-1">
                 <h4>Cidade</h4>
               </label>
-              <select id="cidade" name="cidade" value={localData.cidade} onChange={handleChange} disabled={!municipios.length} className={`w-full px-4 py-2 border rounded-lg bg-white focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 ${errors.cidade ? 'border-red-500' : 'border-gray-300'}`}>
+              <select id="cidade" name="cidade" value={localData.cidade} onChange={handleChange} disabled={!municipios.length} className={`w-full px-4 py-2 border rounded-lg bg-white outline-none transition-all duration-200 focus:ring-2 focus:ring-azul-botao focus:border-transparent disabled:bg-gray-100 ${errors.cidade ? 'border-red-500' : 'border-gray-300'}`}>
                 <option value="">{municipios.length ? "Selecione a Cidade" : "Selecione um Estado"}</option>
                 {municipios.map((mun) => (
                   <option key={mun.id} value={mun.nome}>
@@ -323,7 +292,7 @@ export default function SecondPagePaciente() {
                 {errors.cidade ? (
                   <p className="text-sm text-red-600">{errors.cidade}</p>
                 ) : (
-                  <p className="text-[15px] text-[#0F276D] font-semibold">Selecione sua cidade</p>
+                  <p className="text-[15px] text-azul-principal font-semibold">Selecione sua cidade</p>
                 )}
               </div>
             </div>

--- a/src/components/FormCadastroLayout.jsx
+++ b/src/components/FormCadastroLayout.jsx
@@ -14,7 +14,7 @@ export default function FormCadastroLayout({
   // Função para estilizar as etapas do stepper
   const getStepClass = (currentStep) => {
     if (currentStep === step) {
-      return "bg-[#1D4BD1] text-white";
+      return "bg-azul-botao text-white";
     } else if (currentStep < step) {
       return "bg-green-500 text-white";
     }
@@ -22,13 +22,13 @@ export default function FormCadastroLayout({
   };
 
   return (
-    <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-[0_8px_16px_rgba(113,146,255,0.25)] p-6 sm:p-8 md:p-12">
+    <div className="w-full max-w-[1344px] bg-white rounded-2xl shadow-card-igreja p-6 sm:p-8 md:p-12">
       {/* Títulos do Card */}
       <div className="text-center mb-8">
-        <h3 className="text-2xl md:text-[28px] font-bold text-[#0A1B4B]">
+        <h3 className="text-2xl md:text-[28px] font-bold text-azul-titulo">
           Cadastro de Paciente/Responsável
         </h3>
-        <h5 className="text-[#0A1B4B] font-normal text-[16px] mt-4">
+        <h5 className="text-azul-titulo font-normal text-[16px] mt-4">
           Atendimento social, jurídico e de saúde, rápido e integrado.
         </h5>
       </div>
@@ -93,7 +93,7 @@ export default function FormCadastroLayout({
 
       <form className="space-y-10" onSubmit={onSubmit}>
         <section>
-          <h3 className="text-xl font-bold text-[#0A1B4B] mb-6 text-center pl-4">
+          <h3 className="text-xl font-bold text-azul-titulo mb-6 text-center pl-4">
             {title}
           </h3>
           {children}
@@ -110,7 +110,7 @@ export default function FormCadastroLayout({
                          font-bold text-lg rounded-[5px] transition-all duration-300
                          ${isSubmitDisabled || submitLoading
                            ? 'bg-gray-300 text-gray-500 border-gray-300 cursor-not-allowed'
-                           : 'bg-white text-[#193FB0] border border-[#193FB0] shadow-[0_8px_16px_rgba(113,146,255,0.25)] hover:bg-[#193FB0] hover:text-white'
+                           : 'bg-white text-azul-botao border border-azul-botao shadow-card-igreja hover:bg-azul-botao hover:text-white'
                          }`}
             >
               {submitLoading ? (
@@ -129,9 +129,9 @@ export default function FormCadastroLayout({
             <button
               type="button"
               className="w-full lg:w-[612px] h-[56px] flex justify-center items-center
-                         bg-white text-[#BE3E1A] font-bold text-lg
-                         border border-[#BE3E1A] rounded-[5px]
-                         hover:bg-[#BE3E1A] hover:text-white
+                         bg-white text-vermelho-aviso font-bold text-lg
+                         border border-vermelho-aviso rounded-[5px]
+                         hover:bg-vermelho-aviso hover:text-white
                          transition-all duration-300"
                          // 4. Conectamos a função 'onCancel'
               onClick={onCancel}
@@ -140,7 +140,7 @@ export default function FormCadastroLayout({
             </button>
           </div>
         </div>
-        <h6 className="text-center font-bold text-[16px] text-[#0A1B4B]">
+        <h6 className="text-center font-bold text-[16px] text-azul-titulo">
           Suas informações são confidenciais e protegidas.
         </h6>
       </form>

--- a/src/components/FormField.jsx
+++ b/src/components/FormField.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+const FormField = ({
+  label,
+  id,
+  type = "text",
+  placeholder,
+  colSpan = "col-span-1",
+  helperText,
+  value,
+  onChange,
+  error,
+  required = false,
+  showHelper = true,
+}) => {
+  const showError = Boolean(error);
+
+  return (
+    <div className={`${colSpan} flex flex-col`}>
+      <label
+        htmlFor={id}
+        //  Usando a cor global text-azul-principal
+        className="block text-lg md:text-[20px] font-bold text-azul-principal mb-1"
+      >
+        {label} {required && <span className="text-red-500">*</span>}
+      </label>
+
+      <input
+        type={type}
+        id={id}
+        name={id}
+        placeholder={placeholder}
+        //  focus  usa a cor da marca azul-botao e transição suave
+        className={`w-full px-4 py-2 border rounded-lg outline-none transition-all duration-200
+          focus:ring-2 focus:ring-azul-botao focus:border-transparent
+          ${showError ? "border-red-500" : "border-gray-300"}
+        `}
+        value={value}
+        onChange={onChange}
+      />
+
+      <div className="min-h-[1.25rem] mt-1">
+        {showError ? (
+          <p className="text-sm text-red-600">{error}</p>
+        ) : (
+          showHelper && (
+            // usa a cor global text-azul-principal
+            <p className="text-[15px] text-azul-principal font-semibold">
+              {helperText}
+            </p>
+          )
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FormField;

--- a/src/index.css
+++ b/src/index.css
@@ -4,4 +4,15 @@
 
 @theme {
   --font-sans: "Nokora", sans-serif;
+
+  /* Cores Personalizadas */
+  --color-azul-principal: #0F276D;   /* Texto principal */
+  --color-azul-titulo: #0A1B4B;      /* Títulos */
+   --color-azul-botao: #193FB0;       /* Botão Salvar/Hover */
+   --color-vermelho-aviso: #BE3E1A;    /* Botão Cancelar */
+   --color-fundo-card: #FFFFFF;
+  --color-azul-principal: #1133AA;   /* Texto principal */
+
+  /* sombra azul do card */
+   --shadow-card-igreja: 0 8px 16px rgba(113, 146, 255, 0.25);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Nokora:wght@100..900&family=Stack+Sans+Text:wght@200..700&display=swap');
+
 @import "tailwindcss";
+
+@theme {
+  --font-sans: "Nokora", sans-serif;
+}


### PR DESCRIPTION
Criação de Componente Global (FormField):

Extraído o componente FormField (anteriormente definido localmente em cada página) para um arquivo global em src/components/FormField.jsx.

Este componente agora é reutilizável em todas as etapas do cadastro, aceitando propriedades flexíveis como type, label, helperText, value, onChange, entre outras.

Garante que todos os campos de entrada (inputs) do sistema tenham a mesma aparência e comportamento.

Padronização de Estilos (Tailwind CSS ):

Definidas variáveis CSS globais no arquivo src/index.css dentro da diretiva @theme, centralizando as cores e sombras da identidade visual do projeto:

--color-azul-principal: Cor primária dos textos e labels.

--color-azul-titulo: Cor dos títulos principais.

--color-azul-botao: Cor padrão dos botões de ação e anéis de foco.

--color-vermelho-aviso: Cor para ações secundárias ou de cancelamento.

--color-fundo-card: Cor de fundo dos cartões.

--shadow-card-igreja: Sombra personalizada e consistente para os cards.

Substituídos todos os códigos hexadecimais "hardcoded" (ex: #0F276D, #193FB0) pelas novas classes semânticas do Tailwind (ex: text-azul-principal, bg-azul-botao) nos componentes e páginas refatorados.

Refatoração das Páginas de Cadastro:

CadastroPacientes.jsx (Etapa 1): Atualizada para importar e usar o FormField global. As cores dos títulos e textos auxiliares foram ajustadas para as novas variáveis.

SecondPagePaciente.jsx (Etapa 2 - Endereço): Código duplicado do FormField removido. Todos os campos de endereço agora utilizam o componente global. Os selects manuais (Estado e Cidade) foram estilizados para corresponder visualmente aos inputs padronizados.

FormCadastroLayout.jsx: O layout base do formulário (card, stepper e botões) foi atualizado para usar as novas variáveis de cor e sombra, garantindo que a consistência do cadastro esteja visualmente coerente em todas as etapas.